### PR TITLE
Fix: Make sure email addresses with new TLDs pass validation

### DIFF
--- a/common/djangoapps/external_auth/views.py
+++ b/common/djangoapps/external_auth/views.py
@@ -16,7 +16,6 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, authenticate, login
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
 
 if settings.FEATURES.get('AUTH_USE_CAS'):
@@ -49,6 +48,7 @@ from ratelimitbackend.exceptions import RateLimitException
 import student.views
 from xmodule.modulestore.django import modulestore
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from util.validation_utils import validate_email
 
 log = logging.getLogger("edx.external_auth")
 AUDIT_LOG = logging.getLogger("audit")

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -20,7 +20,7 @@ from django.contrib import messages
 from django.core.context_processors import csrf
 from django.core import mail
 from django.core.urlresolvers import reverse
-from django.core.validators import validate_email, ValidationError
+from django.core.validators import ValidationError
 from django.db import IntegrityError, transaction
 from django.http import (HttpResponse, HttpResponseBadRequest, HttpResponseForbidden,
                          HttpResponseServerError, Http404)
@@ -53,6 +53,7 @@ from student.models import (
     create_comments_service_user, PasswordHistory, UserSignupSource,
     DashboardConfiguration, LinkedInAddToProfileConfiguration, ManualEnrollmentAudit, ALLOWEDTOENROLL_TO_ENROLLED)
 from student.forms import AccountCreationForm, PasswordResetFormNoActive
+from util.validation_utils import validate_email
 
 from verify_student.models import SoftwareSecurePhotoVerification  # pylint: disable=import-error
 from certificates.models import CertificateStatuses, certificate_status_for_student

--- a/common/djangoapps/util/tests/test_validation_utils.py
+++ b/common/djangoapps/util/tests/test_validation_utils.py
@@ -1,0 +1,57 @@
+"""
+Tests for validation_utils.py
+"""
+
+from ddt import ddt, data
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from util.validation_utils import validate_email
+
+
+@ddt
+class ValidationUtilsTest(TestCase):
+    """
+    Tests for validate_email
+
+    Reuses test cases from Django 1.4.21 validator tests;
+    adds test cases for new TLDs.
+    """
+
+    @data(
+        'email@here.com',
+        'weirder-email@here.and.there.com',
+        'email@[127.0.0.1]',
+        # Quoted-string format
+        '"\\\011"@here.com',
+        # New TLDs (not supported by Django 1.4.21)
+        'email@here.solutions',
+        'weirder-email@here.and.there.academy',
+        '"\\\011"@here.boutique',
+    )
+    def test_validate_email_valid(self, email):
+        self.assertIsNone(validate_email(email))
+
+    @data(
+        None,
+        '',
+        'abc',
+        'a @x.cz',
+        'something@@somewhere.com',
+        'email@127.0.0.1',
+        # Quoted-string format (CR not allowed)
+        '"\\\012"@here.com'
+        # Trailing newlines in username or domain not allowed
+        'a@b.com\n',
+        'a\n@b.com',
+        '"test@test"\n@example.com',
+        'a@[127.0.0.1]\n',
+        # New TLDs (not supported by Django 1.4.21)
+        'something@@somewhere.camera',
+        '"\\\012"@here.careers'
+        'a@b.bargains\n',
+        'a\n@b.builders',
+        '"test@test"\n@example.clothing',
+    )
+    def test_validate_email_invalid(self, email):
+        self.assertRaises(ValidationError, validate_email, email)

--- a/common/djangoapps/util/validation_utils.py
+++ b/common/djangoapps/util/validation_utils.py
@@ -1,0 +1,16 @@
+import re
+
+from django.core.validators import EmailValidator
+from django.utils.translation import ugettext_lazy as _
+
+# This is a modified version of the regexp that Django 1.4.21 uses to validate email addresses.
+# It matches email addresses with newer TLDs.
+# Modifications are based on "domain_regex" from Django 1.8.9 (which also matches email addresses with newer TLDs).
+email_re = re.compile(
+    r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*"  # dot-atom
+    # quoted-string, see also http://tools.ietf.org/html/rfc2822#section-3.2.5
+    r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"'
+    r')@((?:[A-Z0-9](?:[A-Z0-9-]{0,247}[A-Z0-9])?\.)+(?:[A-Z]{2,6}|[A-Z0-9-]{2,}(?<!-))\Z)'  # domain
+    r'|\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]\Z', re.IGNORECASE)  # literal form, ipv4 address (SMTP 4.1.3)
+
+validate_email = EmailValidator(email_re, _(u'Enter a valid e-mail address.'), 'invalid')

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -4,7 +4,7 @@ import sys
 from functools import wraps
 
 from django.conf import settings
-from django.core.validators import ValidationError, validate_email
+from django.core.validators import ValidationError
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import server_error
 from django.http import (Http404, HttpResponse, HttpResponseNotAllowed,
@@ -19,6 +19,7 @@ import track.views
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from util.validation_utils import validate_email
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -19,7 +19,6 @@ from django.http import (
 )
 from django.contrib import messages
 from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
 from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
@@ -41,6 +40,7 @@ from student.roles import CourseCcxCoachRole
 from instructor.offline_gradecalc import student_grades
 from instructor.views.api import _split_input_list
 from instructor.views.tools import get_student_from_identifier
+from util.validation_utils import validate_email
 
 from .models import CustomCourseForEdX, CcxMembership
 from .overrides import (

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -19,7 +19,6 @@ from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.mail.message import EmailMessage
 from django.db import IntegrityError
 from django.core.urlresolvers import reverse
-from django.core.validators import validate_email
 from django.utils.translation import ugettext as _
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound
 from django.utils.html import strip_tags
@@ -93,6 +92,8 @@ from submissions import api as sub_api  # installed from the edx-submissions rep
 from certificates import api as certs_api
 
 from bulk_email.models import CourseEmail
+
+from util.validation_utils import validate_email
 
 from .tools import (
     dump_student_extensions,
@@ -593,7 +594,7 @@ def students_update_enrollment(request, course_id):
             language = get_user_email_language(user)
 
         try:
-            # Use django.core.validators.validate_email to check email address
+            # Use custom version of django.core.validators.validate_email to check email address
             # validity (obviously, cannot check if email actually /exists/,
             # simply that it is plausibly valid)
             validate_email(email)  # Raises ValidationError if invalid

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -4,13 +4,14 @@ import datetime
 from pytz import UTC
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
-from django.core.validators import validate_email, validate_slug, ValidationError
+from django.core.validators import validate_slug, ValidationError
 
 from student.models import User, UserProfile, Registration
 from student import views as student_views
 from util.model_utils import emit_setting_changed_event
 
 from openedx.core.lib.api.view_utils import add_serializer_errors
+from util.validation_utils import validate_email
 
 from ..errors import (
     AccountUpdateError, AccountValidationError, AccountUsernameInvalid, AccountPasswordInvalid,


### PR DESCRIPTION
Django 1.4.21 (currently in use on the Harvard instance) uses a regex for validating email addresses that doesn't match email addresses with new TLDs (such as user@example.academy).

This PR fixes that by introducing a modified version of the original regex. Modifications only affect the "domain" portion of the original regex and are based on the `domain_regex` used for email validation in newer versions of Django.
