### PR TITLE
Allow to store multiple anonymous ids for each (user, course).

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -123,7 +123,6 @@ class AnonymousUserId(models.Model):
     user = models.ForeignKey(User, db_index=True)
     anonymous_user_id = models.CharField(unique=True, max_length=32)
     course_id = CourseKeyField(db_index=True, max_length=255, blank=True)
-    unique_together = (user, course_id)
 
 
 def anonymous_id_for_user(user, course_id, save=True):
@@ -161,22 +160,11 @@ def anonymous_id_for_user(user, course_id, save=True):
         return digest
 
     try:
-        anonymous_user_id, __ = AnonymousUserId.objects.get_or_create(
-            defaults={'anonymous_user_id': digest},
+        AnonymousUserId.objects.get_or_create(
             user=user,
-            course_id=course_id
+            course_id=course_id,
+            anonymous_user_id=digest,
         )
-        if anonymous_user_id.anonymous_user_id != digest:
-            log.error(
-                u"Stored anonymous user id %(anonymous_user_id)r for "
-                u"user %(user)r in course %(course_id)r doesn't match "
-                u"computed id %(digest)r", {
-                    "anonymous_user_id": anonymous_user_id.anonymous_user_id,
-                    "user": user,
-                    "course_id": course_id,
-                    "digest": digest,
-                }
-            )
     except IntegrityError:
         # Another thread has already created this entry, so
         # continue


### PR DESCRIPTION
This patch relaxes the uniqueness constraints on anonymous ids by allowing more then one id per user and course to be stored in the database.  This should enable the LMS to reverse the anonymous ids generated before the secret key was changed, as well as the ones generated after the change.

There is a sandbox available, see https://console.opencraft.com/instance/1740/edx-appserver/562/.  I used the sandbox to run the Python tests, since I don't currently have a Eucalyptus devstack.  Unfortunately, the tests don't work very well on a sandbox, so some of them fail.  However, none of the test failures looks related.

Commands to run the tests on the sandbox:

```
/edx/bin/supervisorctl stop all
sudo rm -rf /tmp/mako_*
sudo -s -H -u edxapp
. ~/edxapp_env 
cd ~/edx-platform/
paver test_python
```

If you want to test the LMS, make sure to start all services again using `/etc/bin/supervisorctl start all`.  I don't know a simple way of testing this change from a user point of view.
